### PR TITLE
Fix formatting of architectures field in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Handcrafted 64-bit floating point routines for AVR/arduino microprocess
 paragraph=fp64lib is a library for implementing 64-bit floating point arithmetic on the AVR MegaAVR architecure microprocessors, like the popular Arduino series. Data format is fully compatible with IEEE 754 binary64 standard.
 category=Data Processing
 url=http://fp64lib.org
-architectures=avr atmelavr
+architectures=avr,atmelavr
 includes=fp64lib.h


### PR DESCRIPTION
The `architectures` field of library.properties is a comma separated list. The previous incorrect formatting caused the Arduino IDE to display a warning every time the library was compiled:
```
WARNING: library fp64lib claims to run on (avr atmelavr) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```