### PR TITLE
Fix fp64_log2, issue #16

### DIFF
--- a/fp64_log2.S
+++ b/fp64_log2.S
@@ -71,7 +71,7 @@ GCC_ENTRY __log2
 	out RAMPZ, r0	; restore RAMPZ
 #endif	
 	
-	XCALL _U(fp64_mul)
+	XCALL _U(fp64_div)
 	
 	XJMP _U(__fp64_popBret)		; restore registers and return
 


### PR DESCRIPTION
Correct the implementation to be
log2(x) = log(x) / log(2)